### PR TITLE
Turbolinks

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,4 +225,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/app/assets/javascripts/application.coffee
+++ b/app/assets/javascripts/application.coffee
@@ -12,8 +12,8 @@
 ##
 
 #= require ui_bibz
-#= require turbolinks
 #= require jquery
+#= require turbolinks
 
 # Fonction pour fixer le menu de droite lors du scrolling
 $(window).scroll ->
@@ -30,7 +30,7 @@ $(window).scroll ->
   return
 
 # Smooth Scroll secondary nav
-$(document).on 'page:change', ->
+$(document).on 'ready page:change', ->
   $('.secondary-nav>.nav>.nav-item>a[href*="#"]').on 'click', ->
     if location.pathname.replace(/^\//, '') == @pathname.replace(/^\//, '') and location.hostname == @hostname
       target = $(@hash)
@@ -41,7 +41,7 @@ $(document).on 'page:change', ->
     return
   return
 
-jQuery(document).on 'ready page:change', ->
+jQuery(document).on 'ready page:change page:load turbolinks:load', ->
   offset = 220
   duration = 500
   jQuery(window).scroll ->

--- a/app/views/components/inputs/markdown_editor_fields.html.haml
+++ b/app/views/components/inputs/markdown_editor_fields.html.haml
@@ -5,7 +5,6 @@
   %br
   You can use #{ link_to 'Redcarpet', 'https://github.com/vmg/redcarpet', target: '_blank' } or #{ link_to 'HAML', 'https://github.com/indirect/haml-rails', target: '_blank' } gem to render markdown content.
 
-
 - @sections = sections do |s|
   - s.section title: "Markdown Editor Field" do
     = example do |e|
@@ -27,7 +26,7 @@
                 <span class="fa fa-header"></span>
               </button>
             </div>
-            <div class="btn-group">
+            <div class="btn-group">
               <button class="btn-default btn-sm btn" type="button" title="URL/Link" tabindex="-1" data-provider="bootstrap-markdown" data-handler="bootstrap-markdown-cmdUrl" data-hotkey="Ctrl+L">
                 <span class="fa fa-link"></span>
               </button>


### PR DESCRIPTION
I don't know why we have so much indentation in markdown editor page (for Ruby AND HTML code preview)